### PR TITLE
TOPページのパフォーマンス改善

### DIFF
--- a/src/components/common/GlobalHeader/GlobalHeader.tsx
+++ b/src/components/common/GlobalHeader/GlobalHeader.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { GlobalHeaderMain } from './GlobalHeaderMain';
 
 export const GlobalHeader = () => (

--- a/src/components/common/GlobalHeader/GlobalHeaderMain.tsx
+++ b/src/components/common/GlobalHeader/GlobalHeaderMain.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { Link } from '../Link/Link';
 import { css } from '@emotion/react';
 import { colors } from '../../../styles/color';

--- a/src/components/common/Layout/Layout.tsx
+++ b/src/components/common/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { css } from '@emotion/react';
 import { GlobalStyle } from '../../GlobalStyle';
 import { GlobalHeader } from '../GlobalHeader';

--- a/src/components/common/Link/Link.test.tsx
+++ b/src/components/common/Link/Link.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import { render, screen } from '@testing-library/react';
 import { Link } from './Link';

--- a/src/components/common/Seo/Seo.test.tsx
+++ b/src/components/common/Seo/Seo.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { Seo, SeoProps } from './Seo';
 

--- a/src/components/common/Sidebar/Sidebar.test.tsx
+++ b/src/components/common/Sidebar/Sidebar.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import { profile } from '../../../config/profile';
 import { Sidebar } from './Sidebar';

--- a/src/components/common/Sidebar/Sidebar.tsx
+++ b/src/components/common/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { css } from '@emotion/react';
 import { SidebarTags } from './SidebarTags';
 import { SidebarProfile } from './SidebarProfile';

--- a/src/components/common/Sidebar/SidebarProfile.test.tsx
+++ b/src/components/common/Sidebar/SidebarProfile.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { profile } from '../../../config/profile';
 import { SidebarProfile } from './SidebarProfile';

--- a/src/components/common/Sidebar/SidebarProfile.tsx
+++ b/src/components/common/Sidebar/SidebarProfile.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/react';
 import { colors } from '../../../styles/color';
 import { SidebarSection } from './SidebarSection';

--- a/src/components/common/Sidebar/SidebarSection.test.tsx
+++ b/src/components/common/Sidebar/SidebarSection.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import renderer from 'react-test-renderer';
 import { render, screen } from '@testing-library/react';
 import { SidebarSection } from './SidebarSection';

--- a/src/components/common/Sidebar/SidebarSection.tsx
+++ b/src/components/common/Sidebar/SidebarSection.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { css } from '@emotion/react';
 import { colors } from '../../../styles/color';
 

--- a/src/components/common/Sidebar/SidebarTags.test.tsx
+++ b/src/components/common/Sidebar/SidebarTags.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { SidebarTags } from './SidebarTags';
 

--- a/src/components/common/Sidebar/SidebarTags.tsx
+++ b/src/components/common/Sidebar/SidebarTags.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { css } from '@emotion/react';
 import { Link } from '../Link/Link';
 import { createTagLink } from '../../../lib/link';

--- a/src/components/common/Tag/Tag.tsx
+++ b/src/components/common/Tag/Tag.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { css } from '@emotion/react';
 import { Link } from '../Link/Link';
 import { createTagLink } from '../../../lib/link';

--- a/src/components/common/Tags/Tags.tsx
+++ b/src/components/common/Tags/Tags.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { css } from '@emotion/react';
 import { Tag } from '../Tag/Tag';
 

--- a/src/components/home/Pagination/NextPage.tsx
+++ b/src/components/home/Pagination/NextPage.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { PageItem } from './PageItem';
 import { Link } from '../../common/Link';
 

--- a/src/components/home/Pagination/Pagination.tsx
+++ b/src/components/home/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { css } from '@emotion/react';
 import { range } from '../../../lib/array';
 import { PageNumber } from './PageNumber';

--- a/src/components/home/Pagination/PrevPage.tsx
+++ b/src/components/home/Pagination/PrevPage.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { Link } from '../../common/Link';
 import { PageItem } from './PageItem';
 

--- a/src/components/home/PostEntries/PostEntries.tsx
+++ b/src/components/home/PostEntries/PostEntries.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Fragment } from 'react';
+import { FC, Fragment } from 'react';
 import { css } from '@emotion/react';
 import { Post } from '../../../entities/Post';
 import { colors } from '../../../styles/color';

--- a/src/components/home/PostEntry/PostEntry.tsx
+++ b/src/components/home/PostEntry/PostEntry.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { css } from '@emotion/react';
 import { Link } from '../../common/Link/Link';
 import { Tags } from '../../common/Tags/Tags';

--- a/src/components/home/PostEntry/PostEntry.tsx
+++ b/src/components/home/PostEntry/PostEntry.tsx
@@ -29,7 +29,7 @@ const style = {
 export const PostEntry: FC<PostEntryProps> = ({ post }) => (
     <div css={style.postEntry}>
         <div css={style.date}>{formatDate(post.date)}</div>
-        <Link href={`/post/${post.slug}`} decoration={false}>
+        <Link href={`/post/${post.slug}`} decoration={false} prefetch={false}>
             <h3 css={style.title}>{post.title}</h3>
         </Link>
         <Tags tags={post.tags} css={style.tags} />

--- a/src/components/post/Post/Post.tsx
+++ b/src/components/post/Post/Post.tsx
@@ -1,7 +1,7 @@
 import 'lazysizes';
 import 'lazysizes/plugins/parent-fit/ls.parent-fit';
 
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { PrismAsync as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { css } from '@emotion/react';
 import ReactMarkdown, { Options } from 'react-markdown';

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -8,7 +8,7 @@ export default class MyDocument extends Document {
                 <Head>
                     {/* Global Site Tag (gtag.js) - Google Analytics */}
                     <script
-                        defer
+                        async
                         src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
                     />
                     <script

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -8,7 +8,7 @@ export default class MyDocument extends Document {
                 <Head>
                     {/* Global Site Tag (gtag.js) - Google Analytics */}
                     <script
-                        async
+                        defer
                         src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
                     />
                     <script

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { GetStaticPropsResult } from 'next';
 import { css } from '@emotion/react';
 import { Layout } from '../components/common/Layout/Layout';

--- a/src/pages/page/[page].tsx
+++ b/src/pages/page/[page].tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import {
     GetStaticPathsResult,
     GetStaticProps,

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import {
     GetStaticPathsResult,
     GetStaticProps,

--- a/src/pages/tag/[tag].tsx
+++ b/src/pages/tag/[tag].tsx
@@ -3,7 +3,7 @@ import {
     GetStaticProps,
     GetStaticPropsResult,
 } from 'next';
-import React, { FC } from 'react';
+import { FC } from 'react';
 import { Layout } from '../../components/common/Layout/Layout';
 import { PostEntries } from '../../components/home/PostEntries';
 import { siteMeatadata } from '../../config/siteMetadata';


### PR DESCRIPTION
## やったこと
- import React の削除
- 記事ページのプリフェッチを無効にした
  - 記事ページのプリフェッチによってTOPページで使わないJSが読み込まれていた
  - 読み込んでいるJSが重たく TTI や TBT に影響がでていた。