### PR TITLE
fix: 記事タイトルに/が含まれる時にOGP画像が正常に生成されないバグの対応

### DIFF
--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -43,7 +43,13 @@ export const getStaticProps: GetStaticProps<PostPageProps, Params> = async (
     const tags = usecases.getGroupedTags.invoke();
 
     const title = `${post.title} - ${siteMetadata.title}`;
-    const ogpImage = `https://res.cloudinary.com/dspeq5lct/image/upload/l_text:MPLUSRounded1c-Bold.ttf_52:${post.title},co_rgb:000,w_1020,c_fit,y_-100/v1638629595/blog-ogp.jpg`;
+    // "/"が含まれているとエラーが発生するのでエスケープする
+    // @see: https://support.cloudinary.com/hc/en-us/articles/202521512-How-to-add-a-slash-character-or-any-other-special-characters-in-text-overlays-
+    const encodedPostTitle = encodeURIComponent(post.title).replace(
+        /%2F/g,
+        '%252F'
+    );
+    const ogpImage = `https://res.cloudinary.com/dspeq5lct/image/upload/l_text:MPLUSRounded1c-Bold.ttf_52:${encodedPostTitle},co_rgb:000,w_1020,c_fit,y_-100/v1638629595/blog-ogp.jpg`;
     const seoMetadata: SeoMetadata = {
         ...siteMetadata,
         title: title,


### PR DESCRIPTION
## 原因
OGP画像をURL指定して生成しているので、"/"が含まれる時に正常にURLを生成できなかった